### PR TITLE
Fix 「みつける」にマウスオーバーしたときのカーソル形状

### DIFF
--- a/src/client/app/desktop/views/pages/welcome.vue
+++ b/src/client/app/desktop/views/pages/welcome.vue
@@ -307,6 +307,7 @@ export default Vue.extend({
 
 						> .signin
 						> .signup
+						> .explore
 							cursor pointer
 
 							&:hover


### PR DESCRIPTION
## Summary

followup-to #2

「I」から人差し指で押そうとするアレに
