### PR TITLE
Add 「みつける」を無効にするオプション

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -1311,6 +1311,8 @@ admin/views/instance.vue:
   disable-local-timeline: "Disable the Local Timeline"
   disable-global-timeline: "Disable global timeline"
   disabling-timelines-info: "Even if you disable these timelines, the administrator as well as moderators can use them continually."
+  authorized-profile-directory: "Require login to the profiles directory."
+  disable-profile-directory: "Disable the profiles directory."
   enable-emoji-reaction: "Enable pictograms for reactions"
   use-star-for-reaction-fallback: "Use the star as fallback for unknown reaction"
   invite: "Invite"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1443,6 +1443,8 @@ admin/views/instance.vue:
   disable-local-timeline: "ローカルタイムラインを無効にする"
   disable-global-timeline: "グローバルタイムラインを無効にする"
   disabling-timelines-info: "これらのタイムラインを無効にしても、管理者およびモデレーターは引き続き利用できます。"
+  authorized-profile-directory: "未認証時の「みつける」を無効にする"
+  disable-profile-directory: "「みつける」を無効にする"
   enable-emoji-reaction: "リアクションに絵文字を使えるようにする"
   use-star-for-reaction-fallback: "不明なリアクションのフォールバックに star を使う"
   invite: "招待"

--- a/migration/1700286060236-meta-disableProfileDirectory.ts
+++ b/migration/1700286060236-meta-disableProfileDirectory.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class metaDisableProfileDirectory1700286060236 implements MigrationInterface {
+    name = 'metaDisableProfileDirectory1700286060236'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "meta" ADD "authorizedProfileDirectory" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`COMMENT ON COLUMN "meta"."authorizedProfileDirectory" IS 'Disallow unauthenticated access to the profile directory in web UI.'`);
+        await queryRunner.query(`ALTER TABLE "meta" ADD "disableProfileDirectory" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`COMMENT ON COLUMN "meta"."disableProfileDirectory" IS 'Disable the profile directory in web UI.'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "authorizedProfileDirectory"`);
+        await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "disableProfileDirectory"`);
+    }
+
+}

--- a/src/client/app/admin/views/instance.vue
+++ b/src/client/app/admin/views/instance.vue
@@ -43,6 +43,10 @@
 			<ui-info>{{ $t('disabling-timelines-info') }}</ui-info>
 		</section>
 		<section>
+			<ui-switch v-model="authorizedProfileDirectory" :disabled="disableProfileDirectory">{{ $t('authorized-profile-directory') }}</ui-switch>
+			<ui-switch v-model="disableProfileDirectory">{{ $t('disable-profile-directory') }}</ui-switch>
+		</section>
+		<section>
 			<ui-switch v-model="enableEmojiReaction">{{ $t('enable-emoji-reaction') }}</ui-switch>
 			<ui-switch v-model="useStarForReactionFallback">{{ $t('use-star-for-reaction-fallback') }}</ui-switch>
 		</section>
@@ -270,6 +274,8 @@ export default Vue.extend({
 			disableRegistration: false,
 			disableLocalTimeline: false,
 			disableGlobalTimeline: false,
+			authorizedProfileDirectory: false,
+			disableProfileDirectory: false,
 			enableEmojiReaction: true,
 			useStarForReactionFallback: false,
 			mascotImageUrl: null,
@@ -338,6 +344,8 @@ export default Vue.extend({
 			this.disableRegistration = meta.disableRegistration;
 			this.disableLocalTimeline = meta.disableLocalTimeline;
 			this.disableGlobalTimeline = meta.disableGlobalTimeline;
+			this.authorizedProfileDirectory = meta.authorizedProfileDirectory;
+			this.disableProfileDirectory = meta.disableProfileDirectory;
 			this.enableEmojiReaction = meta.enableEmojiReaction;
 			this.useStarForReactionFallback = meta.useStarForReactionFallback;
 			this.mascotImageUrl = meta.mascotImageUrl;
@@ -481,6 +489,8 @@ export default Vue.extend({
 				disableRegistration: this.disableRegistration,
 				disableLocalTimeline: this.disableLocalTimeline,
 				disableGlobalTimeline: this.disableGlobalTimeline,
+				authorizedProfileDirectory: this.authorizedProfileDirectory,
+				disableProfileDirectory: this.disableProfileDirectory,
 				enableEmojiReaction: this.enableEmojiReaction,
 				useStarForReactionFallback: this.useStarForReactionFallback,
 				mascotImageUrl: this.mascotImageUrl,

--- a/src/client/app/desktop/views/pages/welcome.vue
+++ b/src/client/app/desktop/views/pages/welcome.vue
@@ -32,8 +32,8 @@
 						<span class="signup" @click="signup">{{ $t('@.signup') }}</span>
 						<span class="divider">|</span>
 						<span class="signin" @click="signin">{{ $t('@.signin') }}</span>
-						<span class="divider">|</span>
-						<span class="explore" @click="explore">{{ $t('@.explore') }}</span>
+						<span class="divider" v-if="meta && !(meta.authorizedProfileDirectory || meta.disableProfileDirectory)">|</span>
+						<span class="explore" @click="explore" v-if="meta && !(meta.authorizedProfileDirectory || meta.disableProfileDirectory)">{{ $t('@.explore') }}</span>
 					</p>
 
 					<img v-if="meta" :src="meta.mascotImageUrl" alt="" title="藍" class="char">

--- a/src/client/app/mobile/views/pages/welcome.vue
+++ b/src/client/app/mobile/views/pages/welcome.vue
@@ -12,7 +12,7 @@
 			<div class="signin">
 				<a href="/signin" @click.prevent="signin()">{{ $t('@.signin') }}</a>
 			</div>
-			<div class="explore">
+			<div class="explore" v-if="meta && !(meta.authorizedProfileDirectory || meta.disableProfileDirectory)">
 				<router-link class="explore" to="/explore">{{ $t('@.explore') }}</router-link>
 			</div>
 		</div>

--- a/src/models/entities/meta.ts
+++ b/src/models/entities/meta.ts
@@ -55,6 +55,16 @@ export class Meta {
 	public disableGlobalTimeline: boolean;
 
 	@Column('boolean', {
+		default: false,
+	})
+	public authorizedProfileDirectory: boolean;
+
+	@Column('boolean', {
+		default: false,
+	})
+	public disableProfileDirectory: boolean;
+
+	@Column('boolean', {
 		default: true,
 	})
 	public enableEmojiReaction: boolean;

--- a/src/server/api/endpoints/admin/update-meta.ts
+++ b/src/server/api/endpoints/admin/update-meta.ts
@@ -44,6 +44,20 @@ export const meta = {
 			}
 		},
 
+		authorizedProfileDirectory: {
+			validator: $.optional.nullable.bool,
+			desc: {
+				'ja-JP': '「みつける」の表示に認証を必要とするか否か'
+			}
+		},
+
+		disableProfileDirectory: {
+			validator: $.optional.nullable.bool,
+			desc: {
+				'ja-JP': '「みつける」を無効にするか否か'
+			}
+		},
+
 		enableEmojiReaction: {
 			validator: $.optional.nullable.bool,
 			desc: {
@@ -439,6 +453,14 @@ export default define(meta, async (ps, me) => {
 
 	if (typeof ps.disableGlobalTimeline === 'boolean') {
 		set.disableGlobalTimeline = ps.disableGlobalTimeline;
+	}
+
+	if (typeof ps.authorizedProfileDirectory === 'boolean') {
+		set.authorizedProfileDirectory = ps.authorizedProfileDirectory;
+	}
+
+	if (typeof ps.disableProfileDirectory === 'boolean') {
+		set.disableProfileDirectory = ps.disableProfileDirectory;
 	}
 
 	if (typeof ps.enableEmojiReaction === 'boolean') {

--- a/src/server/api/endpoints/meta.ts
+++ b/src/server/api/endpoints/meta.ts
@@ -83,6 +83,16 @@ export const meta = {
 				optional: false as const, nullable: false as const,
 				description: 'Whether disabled GTL.',
 			},
+			authorizedProfileDirectory: {
+				type: 'boolean' as const,
+				optional: false as const, nullable: false as const,
+				description: 'Whether require login to view the profiles directory.',
+			},
+			disableProfileDirectory: {
+				type: 'boolean' as const,
+				optional: false as const, nullable: false as const,
+				description: 'Whether disabled the profiles directory.',
+			},
 			enableEmojiReaction: {
 				type: 'boolean' as const,
 				optional: false as const, nullable: false as const,
@@ -138,6 +148,8 @@ export default define(meta, async (ps, me) => {
 		disableRegistration: instance.disableRegistration,
 		disableLocalTimeline: instance.disableLocalTimeline,
 		disableGlobalTimeline: instance.disableGlobalTimeline,
+		authorizedProfileDirectory: instance.authorizedProfileDirectory,
+		disableProfileDirectory: instance.disableProfileDirectory,
 		enableEmojiReaction: instance.enableEmojiReaction,
 		driveCapacityPerLocalUserMb: instance.localDriveCapacityMb,
 		driveCapacityPerRemoteUserMb: instance.remoteDriveCapacityMb,

--- a/src/server/api/endpoints/users.ts
+++ b/src/server/api/endpoints/users.ts
@@ -2,6 +2,7 @@ import $ from 'cafy';
 import define from '../define';
 import { Users } from '../../../models';
 import { generateMuteQueryForUsers } from '../common/generate-mute-query';
+import { fetchMeta } from '../../../misc/fetch-meta';
 
 export const meta = {
 	tags: ['users'],
@@ -63,6 +64,14 @@ export const meta = {
 };
 
 export default define(meta, async (ps, me) => {
+	const serverMeta = await fetchMeta();
+	if (
+		serverMeta.disableProfileDirectory ||
+		me == null && serverMeta.authorizedProfileDirectory
+	) {
+		return [];
+	}
+
 	const query = Users.createQueryBuilder('user');
 	query.where('user.isExplorable = TRUE');
 


### PR DESCRIPTION
## Summary

partially import from mei23/misskey#4292 and mei23/misskey#4420

on にすると `/explore` に一切のユーザーを表示しなくなる。
未認証だけ無効にするやつと、ぜんぶ無効にするやつを設けた。

またいずれかを on にすると、ウェルカムページの「みつける」リンクは隠れる。

![image](https://github.com/mgmn/misskey-v11/assets/5103195/2f135e53-6d4b-406f-9fb3-f711ccd4bd70)
